### PR TITLE
Change the local of the enviroment variables in 'postgres' and add them in the 'postgres-users'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,16 +3,27 @@ services:
 
 ############# networking/database core images #############
 
-  postgres:
+postgres:
     image: "postgres:9.4-alpine"
-    environment:
-      POSTGRES_USER: "kong"
-      POSTGRES_DB: "kong"
+    restart: always
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 10s
       timeout: 5s
       retries: 5
+    logging:
+      driver: json-file
+      options:
+        max-size: 100m
+
+  postgres-users:
+    image: postgres:9.4-alpine
+    restart: on-failure
+    command: >
+      bash -c "createuser kong -d -h postgres -U postgres && createdb kong -U kong -h postgres"
+    depends_on:
+      postgres:
+        condition: service_healthy
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
Because of the update of version 9.4.20 of postgres in docker-library/postgres repository, the environment variables can no longer be configured in the 'postgres' container.

Instead of: 

> POSTGRES_USER: "kong"
> POSTGRES_DB: "kong"

Was set the command line to a new container 'postgres-users': 
> bash -c "createuser kong -d -h postgres -U postgres && createdb kong -U kong -h postgres"